### PR TITLE
Add Tailwind CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "tailwindCSS.includeLanguages": {
+    "javascript": "javascript",
+    "html": "html",
+    "erb": "html"
+ },
+  "tailwindCSS.emmetCompletions": true,
+  "files.associations": {
+    "*.html.erb": "erb"
+  },
+  "emmet.includeLanguages": {
+    "html.erb": "html",
+    "erb": "html"
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem "sanitize", "6.0.0"
 # Pagination
 gem "kaminari", "1.2.2"
 
+# Tailwind CSS framework
+gem "tailwindcss-rails", "2.0.21"
+
 group :development, :test do
   # fake data for development and testing
   gem "faker", "3.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.21-aarch64-linux)
+      railties (>= 6.0.0)
     thor (1.2.1)
     timeout (0.3.1)
     turbo-rails (1.3.2)
@@ -329,6 +331,7 @@ DEPENDENCIES
   sidekiq (= 7.0.2)
   sprockets-rails (= 3.4.2)
   stimulus-rails (= 1.2.1)
+  tailwindcss-rails (= 2.0.21)
   turbo-rails (= 1.3.2)
   tzinfo-data
   web-console (= 4.2.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/views/articles/_tailwind.html.erb
+++ b/app/views/articles/_tailwind.html.erb
@@ -1,0 +1,15 @@
+<section class="section-function">
+  <h2 class="header-section">Tailwind CSS Framework</h2>
+
+  <div class="section-description">
+    <p>The content below is made with using Tailwind CSS</p>
+  </div>
+
+  <!--
+    1. https://spaquet.medium.com/tailwind-css-autocomplete-in-vscode-with-ruby-on-rails-63a5fc24a1a4
+    2. https://tailwindcss.com/docs/border-width
+  -->
+  <h1 class="mt-4 mb-4 ml-0 mr-0 p-5 font-serif text-4xl text-red-500 border-8 border-cyan-500">
+    Hello world!!
+  </h1>
+</section>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,3 +7,4 @@
 <%= render partial: 'found_articles', locals: { articles: @found_articles, term: @search_query } %>
 <%= render partial: 'articles_without_caching', locals: { articles: @articles } %>
 <%= render partial: 'articles_with_caching', locals: { articles: @articles } %>
+<%= render partial: 'tailwind' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/bin/helpers.rb
+++ b/bin/helpers.rb
@@ -127,3 +127,11 @@ def sidekiq_stop
   puts "Stopping SIDEKIQ"
   container_bash_exec('rails', 'pkill -f sidekiq')
 end
+
+def tailwind_start
+  container_bash_exec('rails', 'bin/rails tailwindcss:watch', detached = true)
+end
+
+def tailwind_stop
+  container_bash_exec('rails', 'pkill -9 -f tailwindcss', detached = true)
+end

--- a/bin/start
+++ b/bin/start
@@ -7,6 +7,7 @@ rails_db_migrate
 
 puma_start
 sidekiq_start
+tailwind_start
 
 chewy_index
 

--- a/bin/stop
+++ b/bin/stop
@@ -3,5 +3,6 @@ require_relative "./helpers.rb"
 
 puma_stop
 sidekiq_stop
+tailwind_stop
 
 containers_information

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/typography'),
+  ]
+}


### PR DESCRIPTION
This branch is for checking Tailwind CSS framework
Can be merged into the master branch any time.

<img width="1334" alt="Screenshot 2023-01-15 at 15 39 47" src="https://user-images.githubusercontent.com/496713/212543745-285d7720-69b0-4486-bab9-198113f53419.png">

<img width="795" alt="Screenshot 2023-01-15 at 16 33 37" src="https://user-images.githubusercontent.com/496713/212543782-74de671f-9c71-4f67-b130-021adefc8f35.png">


**Conclustions**

1. TW is not so original. I used atomic css approach many years ago. Implementation was different, but the idea was the same.
2. TW has pretty wide ecosystem and it may work pretty well
3. I do not like rails integration, and I do not like having Rails as a full stack framework at all. It is not news.
4. Without good integration with IDE Tailwind is pretty difficult to use. You need to keep in mind not very obvious aliases. 
5. I could not make it work perfect with VScode + ERB in minutes. Probably I need more experiments.