### PR TITLE
Remove already loaded dependency

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'fileutils'
 require_relative '../Rails7StartKit/bin/rails7startkit'
 
 Rails7StartKit.setup!


### PR DESCRIPTION
### Remove unnecessary dependency  

Under Rails7StartKit/bin/rails7startkit, line #3, we require fileutils
