### PR TITLE
Fix docker compose version 2 version check. 

### DIFF
--- a/Rails7StartKit/bin/docker.rb
+++ b/Rails7StartKit/bin/docker.rb
@@ -31,7 +31,7 @@ module Rails7StartKit
     # rubocop:disable Metrics/MethodLength
     def check_docker_compose_v2!
       output = `docker compose version`
-      if output.match(/Docker Compose version v2/)
+      if output.match(/Docker Compose version 2\..*/)
         puts '=> Docker Compose v2 - found!'
       else
         rails7_header


### PR DESCRIPTION
Closes #51

Updated the regex to match the way `docker compose version` outputs the version.

Didn't write tests, because I didn't see any relating to docker. did test it on my local system though and it worked, at least with `Docker Compose version 2.29.0`. 